### PR TITLE
 Add remaining Page vars GH-2

### DIFF
--- a/inspector.html
+++ b/inspector.html
@@ -1,102 +1,175 @@
 <style>
-    #hugo-template-inspector-content {
+    #hti-container{
         position: absolute;
         top: 0px;
         right: 0px;
         background-color: #f9f9f9;
-        padding-top: 10px;
         font-family: muli,avenir,helvetica neue,helvetica,ubuntu,roboto,noto,segoe ui,arial,sans-serif;
         color: #0a1922;
         padding: 10px;
         margin: 10px;
         border-radius: 6px;
         border: 2px #202020 solid;
+        max-width: calc(100% - 20px);
     }
-    #hugo-template-inspector-content ul {
+    #hti-container ul {
         list-style-type: none; 
     }
-    ul .subli {
+    ul .hti-subli {
         list-style-type: square;
+    }
+    #hti-container pre {
+        overflow: scroll;
     }
 </style>
 
-<div id="hugo-template-inspector-content">
-    <ul>
-        <li>.Type: <b>{{ .Type }}</b></li>
-        <li>.Kind: <b>{{ .Kind }}</b></li>
-        <li>.Section: <b>{{ .Section }}</b></li>
-        <li>.Sections:
-            <ul>
-            {{ range .Sections }}
-                <li class="subli"><b>{{ .Name }}</b></li>
-            {{ end }}
-            </ul>
-        </li>
-        <li>.Data:
-            <ul>
-            {{ range .Data }}
-                    <li class="subli">Param 1: <b>{{ . }}</b></li>
-            {{ end }}
-            </ul>
-        </li>
-        <li>.Aliases:</li>
-            <ul>
-            {{ range .Aliases }}
-                <li class="subli"><b>{{ printf "#v%" . }}</b></li>
-            {{ end }}
-            </ul>
-        <li>.Pages:
-            <ul>
-            {{ range .Pages }}
-                <li class="subli"><b>{{ printf "#v%" . }}</b></li>
-            {{ end }}
-            </ul>
-        </li>
-        <li>.Weight: <b>{{ .Weight }}</b></li>
-        <li>.Description: <b>{{ .Description }}</b></li>
-        <li>.Dir: <b>{{ .Dir }}</b></li>
-        <li>.Draft: <b>{{ .Draft }}</b></li>
-        <li>.FuzzyWordCount: <b>{{ .FuzzyWordCount }}</b></li>
-        <li>.IsHome: <b>{{ .IsHome }}</b></li>
-        <li>.IsNode: <b>{{ .IsNode }}</b></li>
-        <li>.IsPage: <b>{{ .IsPage }}</b></li>
-        <li>.RelPermalink: <b>{{ .RelPermalink }}</b></li>
-        <li>.LinkTitle: <b>{{ .LinkTitle }}</b></li>
-        <li>.Title: <b>{{ .Title }}</b></li>
-        <li>.Truncated: <b>{{ .Truncated }}</b></li>
-        <li>.UniqueID: <b>{{ .UniqueID }}</b></li>
-        <li>.PublishDate: <b>{{ .PublishDate }}</b></li>
-        <li>.Date: <b>{{ .Date}}</b></li>
-        <li>.Lastmod: <b>{{ .Lastmod }}</b></li>
-        <li>.NextInSection: <b>{{ .NextInSection }}</b></li>
-        <li>.Next: <b>{{ .Next }}</b></li>
-        <li>.PrevInSection: <b>{{ .PrevInSection }}</b></li>
-        <li>.Prev: <b>{{ .Prev }}</b></li>
+<div id="hti-container">
+    <section id="hti-page-vars">
+        <header>
+            <h3>Page Variables</h3>
+        </header>
+        <ul>
+            <li>.Type: <b>{{ .Type }}</b></li>
+            <li>.Kind: <b>{{ .Kind }}</b></li>
+            <li>.Section: <b>{{ .Section }}</b></li>
+            <li>.Sections:
+                <ul>
+                {{ range .Sections }}
+                    <li class="hti-subli"><b>{{ .Name }}</b></li>
+                {{ end }}
+                </ul>
+            </li>
+            <li>.Data:
+                <ul>
+                {{ range .Data }}
+                        <li class="hti-subli">Param 1: <b>{{ . }}</b></li>
+                {{ end }}
+                </ul>
+            </li>
+            <li>.Aliases:</li>
+                <ul>
+                {{ range .Aliases }}
+                    <li class="hti-subli"><b>{{ printf "#v%" . }}</b></li>
+                {{ end }}
+                </ul>
+            <li>.Pages:
+                <ul>
+                {{ range .Pages }}
+                    <li class="hti-subli"><b>{{ printf "#v%" . }}</b></li>
+                {{ end }}
+                </ul>
+            </li>
+            <li>.AlternativeOutputFormats:
+                <ul>
+                {{ range .AlternativeOutputFormats }}
+                    <li class="hti-subli"><b>{{ printf "#v%" . }}</b></li>
+                {{ end }}
+                </ul>
+            </li>
+            <li>.OutputFormats:
+                <ul>
+                {{ range .OutputFormats }}
+                    <li class="hti-subli"><b>{{ printf "#v%" . }}</b></li>
+                {{ end }}
+                </ul>
+            </li>
+            <li>.Sites:
+                <ul>
+                {{ range .Sites }}
+                    <li class="hti-subli"><b>{{ printf "#v%" . }}</b></li>
+                {{ end }}
+                </ul>
+            </li>
 
-    </ul>
+            <li>.Resources: <b>{{ .Resources }}</b></li>
+            <li>.File: <b>{{ .File }}</b></li>
+            <li>.Keywords: <b>{{ .Keywords }}</b></li>
+            <li>.Language: <b>{{ .Language }}</b></li>
+            <li>.Language.Lang: <b>{{ .Language.Lang }}</b></li>
+            <li>.Hugo: <b>{{ .Hugo }}</b></li>
+            <li>.Weight: <b>{{ .Weight }}</b></li>
+            <li>.Description: <b>{{ .Description }}</b></li>
+            <li>.Summary: <b>{{ .Summary }}</b></li>
+            <li>.Dir: <b>{{ .Dir }}</b></li>
+            <li>.Draft: <b>{{ .Draft }}</b></li>
+            <li>.FuzzyWordCount: <b>{{ .FuzzyWordCount }}</b></li>
+            <li>.WordCount: <b>{{ .WordCount }}</b></li>
+            <li>.ReadingTime: <b>{{ .ReadingTime }}</b></li>
+            <li>.IsHome: <b>{{ .IsHome }}</b></li>
+            <li>.IsNode: <b>{{ .IsNode }}</b></li>
+            <li>.IsPage: <b>{{ .IsPage }}</b></li>
+            <li>.IsTranslated: <b>{{ .IsTranslated }}</b></li>
+            <li>.RelPermalink: <b>{{ .RelPermalink }}</b></li>
+            <li>.Permalink: <b>{{ .Permalink }}</b></li>
+            <li>.RSSLink(DEPRECATED): <b>{{ .RSSLink }}</b></li>
+            <li>.LinkTitle: <b>{{ .LinkTitle }}</b></li>
+            <li>.Title: <b>{{ .Title }}</b></li>
+            <li>.Truncated: <b>{{ .Truncated }}</b></li>
+            <li>.UniqueID: <b>{{ .UniqueID }}</b></li>
+            <li>.PublishDate: <b>{{ .PublishDate }}</b></li>
+            <li>.Date: <b>{{ .Date }}</b></li>
+            <li>.ExpiryDate: <b>{{ .ExpiryDate }}</b></li>
+            <li>.Lastmod: <b>{{ .Lastmod }}</b></li>
+            <li>.NextInSection: <b>{{ .NextInSection }}</b></li>
+            <li>.Next: <b>{{ .Next }}</b></li>
+            <li>.PrevInSection: <b>{{ .PrevInSection }}</b></li>
+            <li>.Prev: <b>{{ .Prev }}</b></li>
+            <li>.Site: <b>{{ .Site }}</b></li>
+            <li>.Sites.First: <b>{{ .Sites.First }}</b></li>
+            <li>.Translations: <b>{{ .Translations }}</b></li>
+            <li>.TranslationKey: <b>{{ .TranslationKey }}</b></li>
+            <li>.Truncated: <b>{{ .Truncated }}</b></li>
+        </ul>
+        <section id="hti-page-content-container">
+            <h4>.Content</h4> 
+            <div id="hti-page-content">
+                <pre>
+                {{ .Content }}
+                </pre>
+            </div>
+            <h4>.Plain</h4>
+            <div id="hti-plain-page-content">
+                <pre>
+                {{ .Plain }}
+                </pre>
+            </div>
+            <h4>.PlainWords</h4>
+            <div id="hti-plain-words-page-content">
+                <pre>
+                {{ .PlainWords }}
+                </pre>
+            </div>
+            <h4>.RawContent</h4>
+            <div id="hti-raw-page-content">
+                <pre>
+                {{ .RawContent }}
+                </pre>
+            </div>
+            <h4>.TableOfContents</h4>
+            <div id="hti-table-of-contents">
+                {{ .TableOfContents}}
+            </div>
+        </section>
+    </section>
 </div>
 <script type="text/javascript">
-	var toggle = function() {
-    	var on = false;
+	var htiToggle = function() {
+    	var htiOn = false;
 		return function() {
-			if(!on) {
-				on = true;
-				document.getElementById('hugo-template-inspector-content').setAttribute('style','display:none;');
+			if(!htiOn) {
+				htiOn = true;
+				document.getElementById('hti-container').setAttribute('style','display:none;');
 				return;
 			}
-			document.getElementById('hugo-template-inspector-content').setAttribute('style','display:block;');
-			on = false;
+			document.getElementById('hti-container').setAttribute('style','display:block;');
+			htiOn = false;
 		}
 	}();
-
-	//toggle(); //Set OFF as default    
-
+	//htiToggle(); //Set OFF as default    
 	document.addEventListener('keydown',function(e) {
 	   var key = e.keyCode || e.which;
 	   if(key === 81) {
-		  toggle();
+		  htiToggle();
 	   }
 	}, false);
-
 </script>
-


### PR DESCRIPTION
Update structure to organize Page vars section

Fix namespace typos

Add .AlternativeOutputFormats var

Add .Content var

Update hti container css ID

Add .ExpiryDate var

Add .File var

Add .Hugo var

Add .Keywords var

Add .Language and .Language.Lang vars

Add .OutputFormats var

Add .Permalink var

Add .Plain and .PlainWords vars

Add .RSSLink var

Add deprecation notice to .RSSLink

Add .RawContent var & fix headings

Add <pre> tags to conent blocks

Add styles to handle large content

Add .ReadingTime var

Add .Resources var

Fix .Data var

Add .Site var

Add .Sites var

Add Sites.First var

Add .Summary var

Add .TableOfContents var

Add .Translations var

Add .TranslationKey var

Add .Truncated var

Add .WordCount var

The details of the commits here are a little awkward, but mostly complete and accurate. Still working on my git workflow.